### PR TITLE
Fixed javascript error on load if EmberHammerOptions is not defined

### DIFF
--- a/ember-hammer.js
+++ b/ember-hammer.js
@@ -156,8 +156,8 @@
     */
     hammerOptions: null
   });
-})(window, Ember, Hammer, false || emberHammerOptions);
-if (emberHammerOptions) {
+})(window, Ember, Hammer, false || (typeof emberHammerOptions === 'undefined' ? false : emberHammerOptions));
+if (typeof emberHammerOptions !== 'undefined') {
   emberHammerOptions = null;
   delete emberHammerOptions;
 }


### PR DESCRIPTION
Was getting a javascript undefined error on load. Is the emberHammerOptions a legacy?
