### PR TITLE
fixed stopPropagation error

### DIFF
--- a/ember-hammer.js
+++ b/ember-hammer.js
@@ -106,7 +106,11 @@
           hammer.on(value.toLowerCase(), function (event) {
             var output = self.gestures[value].apply(self, Array.prototype.slice.call(arguments));
             if (output === false) {
-              event.srcEvent.stopPropagation();
+              if (typeof event.stopPropagation !== 'undefined') {
+                event.stopPropagation();
+              } else {
+                event.srcEvent.stopPropagation();
+              }
             }
             return output;
           });


### PR DESCRIPTION
Part of effort to support 2.x, since the Hammer 2.x's event type does not have a `stopPropagation` and instead requires that we call `srcEvent.stopPropagation` instead. This fixes issue with Hammer 2.x where returning false from an event callback will throw an error.
