### PR TITLE
Ember.View is deprecated and shouldn't be used anymore

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ember-hammer
 ============
-ember-hammer is a neat interface for defining [Hammer.js](https://github.com/EightMedia/hammer.js) gestural behaviour in your [Ember.js](http://www.emberjs.com) Views. It is easy to use and lightweight.
+ember-hammer is a neat interface for defining [Hammer.js](https://github.com/EightMedia/hammer.js) gestural behaviour in your [Ember.js](http://www.emberjs.com) Components. It is easy to use and lightweight.
 
 Note: Hammer.js 2.x support is currently experimental.
 
@@ -10,7 +10,7 @@ Note: Hammer.js 2.x support is currently experimental.
 /* ES6 Modules Example */
 import Ember from 'ember';
 
-export default Ember.View.extend({
+export default Ember.Component.extend({
   hammerOptions: {
     swipe_velocity: 0.5
   },
@@ -23,7 +23,7 @@ export default Ember.View.extend({
 });
 
 /* Globals Example */
-App.SomeView = Ember.View.extend({
+App.SomeComponent = Ember.Component.extend({
   hammerOptions: {
     swipe_velocity: 0.5
   },
@@ -50,7 +50,7 @@ In your `Brocfile.js` (which should be in the root of your project directory), b
     app.import('bower_components/hammerjs/hammer.js');
     app.import('bower_components/ember-hammer/ember-hammer.js');
 
-That should be it. You'll now be able to define a `gestures` object in your views.
+That should be it. You'll now be able to define a `gestures` object in your components.
 
 ###With globals
 
@@ -58,7 +58,7 @@ First, include the `ember-hammer.js` file into your asset delivery pipeline (ide
 
 ###Once included
 
-Next, define a `gestures` object in any view that you'd like to enable gestural behaviour for. Inside this object, define any Hammer.js gestural event name as a key, with the callback function to be executed as the value.
+Next, define a `gestures` object in any component that you'd like to enable gestural behaviour for. Inside this object, define any Hammer.js gestural event name as a key, with the callback function to be executed as the value.
 
 ```javascript
 gestures: {
@@ -76,15 +76,15 @@ See the full example at the top of the README.
 
 ###Passing options to Hammer.js
 
-You can optionally define a `hammerOptions` object inside your view to specify any specific options that should be passed into Hammer.js. Options defined inside the `hammerOptions` object are specific to that view.
+You can optionally define a `hammerOptions` object inside your component to specify any specific options that should be passed into Hammer.js. Options defined inside the `hammerOptions` object are specific to that component.
 
-If you'd like to set global options for all instances of Hammer.js (applicable to all views), you can use `emberHammerOptions.hammerOptions`. See the section on emberHammerOptions below.
+If you'd like to set global options for all instances of Hammer.js (applicable to all components), you can use `emberHammerOptions.hammerOptions`. See the section on emberHammerOptions below.
 
 ###Event Callback Function
 
 The callback function is passed a single `event` argument, which is provided by Hammer.js.
 
-The `this` context of the callback will be set to the view object, so you can access any methods on the view that you may need to get the desired behaviour.
+The `this` context of the callback will be set to the component object, so you can access any methods on the component that you may need to get the desired behaviour.
 
 ###Event bubbling
 
@@ -122,7 +122,7 @@ window.emberHammerOptions = {
 };
 ```
 
-`emberHammerOptions.hammerOptions` will be passed into every instance of Hammer.js. You can override these options and set additional ones for a specific `Ember.View` by setting the `hammerOptions` key inside the view object. See the relevant section above for more information.
+`emberHammerOptions.hammerOptions` will be passed into every instance of Hammer.js. You can override these options and set additional ones for a specific `Ember.Component` by setting the `hammerOptions` key inside the component object. See the relevant section above for more information.
 
 ##License
 

--- a/bower.json
+++ b/bower.json
@@ -1,12 +1,12 @@
 {
   "name": "ember-hammer",
   "main": "ember-hammer.js",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "homepage": "https://github.com/chriswessels/ember-hammer",
   "authors": [
     "Chris Wessels <undefined.za@gmail.com>"
   ],
-  "description": "ember-hammer is a neat interface for defining Hammer.js gestural behaviour in your Ember.js Views.",
+  "description": "ember-hammer is a neat interface for defining Hammer.js gestural behaviour in your Ember.js Components.",
   "moduleType": [
     "globals"
   ],

--- a/ember-hammer.js
+++ b/ember-hammer.js
@@ -10,11 +10,11 @@
     hammerOptions: null,
     ignoreEvents: ['touchmove', 'touchstart', 'touchend', 'touchcancel']
   },
-  viewProperties = componentProperties = {
+  componentProperties = {
     /**
-    * This property is the public interface for defining gestural behaviour for a given view.
+    * This property is the public interface for defining gestural behaviour for a given component.
     * @example
-    *     App.SomeView = Ember.View.extend({
+    *     App.SomeComponent = Ember.Component.extend({
     *       gestures: {
     *         swipeLeft: function (event) {
     *           // do something like send an event down the controller/route chain
@@ -26,9 +26,9 @@
     */
     gestures: null,
     /**
-    * This property allows you to pass view-specific options to Hammer.js.
+    * This property allows you to pass component-specific options to Hammer.js.
     * @example
-    *     App.SomeView = Ember.View.extend({
+    *     App.SomeComponent = Ember.Component.extend({
     *       hammerOptions: {
     *         swipe_velocity: 0.5
     *       }
@@ -46,7 +46,7 @@
     /**
     * This function will ensure that `_hammerInstance` is populated with an instance of Hammer for `this.get('element')`.
     * The instance is cached and is only set if `this.gestures` is truthy. This means an instance of Hammer will only
-    * be created if gesture callbacks have been specified for the view in the `gestures` object.
+    * be created if gesture callbacks have been specified for the component in the `gestures` object.
     * @method _setupHammer
     * @private
     *
@@ -63,7 +63,7 @@
     /**
     * This function will ensure that `_hammerInstance` has been populated by calling `this._setupHammer`.
     * It then iterates over the keys in the `gestures` object and attaches a glue function to the relevant
-    * event using `hammer_instance.on` that changes the callback context (`this`) to the View object
+    * event using `hammer_instance.on` that changes the callback context (`this`) to the Component object
     * for each of the callbacks specified.
     * Gesture events will naturally bubble up the DOM tree, so if you want to cancel bubbling in your callback,
     * just return `false`.
@@ -103,7 +103,7 @@
       }
     },
     /**
-    * This will call `dispose` on the Hammer instance for the view and then nullify it.
+    * This will call `dispose` on the Hammer instance for the component and then nullify it.
     * @method _teardownGestures
     * @private
     */
@@ -115,8 +115,8 @@
       this.set('_hammerInstance', null);
     },
     /**
-    * This function is attached to the `didInsertElement` view event that is fired.
-    * It will call `this._setupGestures` to initialise gestural behaviour for the view upon insertion into the DOM.
+    * This function is attached to the `didInsertElement` component event that is fired.
+    * It will call `this._setupGestures` to initialise gestural behaviour for the component upon insertion into the DOM.
     * @method _onDidInsertElement
     * @private
     */
@@ -125,7 +125,7 @@
       return this._super(Array.prototype.slice.call(arguments));
     }),
     /**
-    * This function is attached to the `willDestroy` view event that is fired.
+    * This function is attached to the `willDestroy` component event that is fired.
     * @method _onWillDestroy
     * @private
     */
@@ -134,7 +134,7 @@
       return this._super(Array.prototype.slice.call(arguments));
     }),
     /**
-    * This function is observes the `gestures` property on the view.
+    * This function is observes the `gestures` property on the component.
     * Under normal circumstances `gestures` will never change, so this observer
     * is never fired. It does however ensure that if the `gestures` object is
     * patched, gestural behaviour is updated.
@@ -161,7 +161,6 @@
       return this._super(Array.prototype.slice.call(arguments));
     }
   });
-  Ember.View.reopen(viewProperties);
   Ember.Component.reopen(componentProperties);
 })(window, Ember, Hammer, (typeof emberHammerOptions === 'undefined' ? false : emberHammerOptions));
 if (typeof emberHammerOptions !== 'undefined') {


### PR DESCRIPTION
`Ember.View` is deprecated in Ember 1.13 and will be removed in Ember 2.0. This PR gets rid of deprecation message and prepares the lib for Ember 2.0. It addresses https://github.com/chriswessels/ember-hammer/issues/13 too.