### PR TITLE
Fix defining customEvents in Ember.Application

### DIFF
--- a/ember-hammer.js
+++ b/ember-hammer.js
@@ -158,7 +158,7 @@
       });
       this.set('events', events);
 
-      return this._super(Array.prototype.slice.call(arguments));
+      return this._super.apply(this, Array.prototype.slice.call(arguments));
     }
   });
   Ember.Component.reopen(componentProperties);


### PR DESCRIPTION
This PR solves: https://github.com/chriswessels/ember-hammer/issues/16

By using `apply()` we pass parameters separately instead of passing an array.